### PR TITLE
[FIX] querydsl로 로그인 시 권한 한번에 조회하여 N+1 문제 해결

### DIFF
--- a/qiin-be/src/main/java/com/beyond/qiin/domain/auth/service/command/AuthCommandServiceImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/auth/service/command/AuthCommandServiceImpl.java
@@ -119,9 +119,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
     // 사용자 역할 및 권한 조회
     private UserRoleContextDto getUserRoleContext(final Long userId) {
-        String role = userRoleReader.findRoleNameByUserId(userId);
-        List<String> permissions = userRoleReader.findPermissionsByUserId(userId);
-        return UserRoleContextDto.of(role, permissions);
+        return userRoleReader.readUserRoleContext(userId);
     }
 
     // AccessToken + RefreshToken 동시 발급

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/iam/repository/UserRoleJpaRepository.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/iam/repository/UserRoleJpaRepository.java
@@ -1,12 +1,13 @@
 package com.beyond.qiin.domain.iam.repository;
 
 import com.beyond.qiin.domain.iam.entity.UserRole;
+import com.beyond.qiin.domain.iam.repository.querydsl.UserRoleQueryRepository;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserRoleJpaRepository extends JpaRepository<UserRole, Long> {
+public interface UserRoleJpaRepository extends JpaRepository<UserRole, Long>, UserRoleQueryRepository {
 
     // 기존 역할명 확인
     boolean existsByRole_RoleName(final String roleName);

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/iam/repository/querydsl/UserRoleQueryRepository.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/iam/repository/querydsl/UserRoleQueryRepository.java
@@ -1,0 +1,9 @@
+package com.beyond.qiin.domain.iam.repository.querydsl;
+
+import com.beyond.qiin.domain.iam.entity.UserRole;
+import java.util.Optional;
+
+public interface UserRoleQueryRepository {
+
+    Optional<UserRole> findUserRoleWithPermissions(final Long userId);
+}

--- a/qiin-be/src/main/java/com/beyond/qiin/domain/iam/repository/querydsl/UserRoleQueryRepositoryImpl.java
+++ b/qiin-be/src/main/java/com/beyond/qiin/domain/iam/repository/querydsl/UserRoleQueryRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.beyond.qiin.domain.iam.repository.querydsl;
+
+import static com.beyond.qiin.domain.iam.entity.QPermission.permission;
+import static com.beyond.qiin.domain.iam.entity.QRole.role;
+import static com.beyond.qiin.domain.iam.entity.QRolePermission.rolePermission;
+import static com.beyond.qiin.domain.iam.entity.QUserRole.userRole;
+
+import com.beyond.qiin.domain.iam.entity.UserRole;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRoleQueryRepositoryImpl implements UserRoleQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<UserRole> findUserRoleWithPermissions(final Long userId) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(userRole)
+                .join(userRole.role, role)
+                .fetchJoin()
+                .join(role.rolePermissions, rolePermission)
+                .fetchJoin()
+                .join(rolePermission.permission, permission)
+                .fetchJoin()
+                .where(userRole.user.id.eq(userId))
+                .fetchOne());
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
- 기존에는 로그인 시 권한 조회 시 LIST타입으로 일일히 1개씩 조회하여 N+1 문제 발생

## ✨ 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [x] 버그 수정
- [ ] flyway 버전 변경 (현재 버전 입력)
- [ ] 기타 (설명 필요)

## 🔀 작업한 브랜치 (Working Branch)
- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- hotfix/185-nplusone

## #️⃣ 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요 (필수). 
- Closes [#185](https://github.com/beyond-sw-camp/be18-fin-jelly-queuein-be/issues/185)

## ℹ️ 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)
-